### PR TITLE
Move angular-mocks to dev dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,9 @@
   "main": "./src/angular-mixpanel.js",
   "dependencies": {
     "angular": "1.2.x",
-    "angular-mocks": "~1.2.18",
     "mixpanel": "~2.2.0"
+  },
+  "devDependencies": {
+    "angular-mocks": "~1.2.18"
   }
 }


### PR DESCRIPTION
Bower has another block for declaring development dependencies..
Also it would be very helpful to work with wiredep (http://stephenplusplus.github.io/grunt-wiredep)
