### PR TITLE
Include main field in package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "angular-mixpanel",
   "version": "1.1.0",
+  "main": "src/angular-mixpanel.js",
   "repository": {
     "type": "git",
     "url": "http://github.com/kuhnza/angular-mixpanel.git"


### PR DESCRIPTION
This adds support for tools like browserify that use npm-installed dependencies.
